### PR TITLE
Allow writing hex file (and streams and strings).

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,7 +76,7 @@ use 2 here).
 
 ### [Function] write-hex-to-file
 
-    READ-HEX-FROM-FILE offset-and-data file &optional (chunk-size *default-chunk-size*) vector-size) => NIL
+    WRITE-HEX-TO-FILE offset-and-data file &optional (chunk-size *default-chunk-size*) vector-size) => NIL
 
 Write Intel HEX format to a file named FILENAME.
 
@@ -85,7 +85,7 @@ passed to OPEN call.
 
 ### [Function] write-hex-to-string
 
-    READ-HEX-FROM-STRING offset-and-data &optional (chunk-size *default-chunk-size*) vector-size) => NIL
+    WRITE-HEX-TO-STRING offset-and-data &optional (chunk-size *default-chunk-size*) vector-size (if-exists :error)) => NIL
 
 Write Intel HEX format to string.
 Parameters are analogous to WRITE-HEX.

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,17 @@ To read the file, just call READ-HEX-FROM-FILE function as following and get a b
     (intel-hex:read-hex-from-file 512 "/path/to/hex-file.hex")
     => #(0 0 0 ... #x21 #x46 #x01 ...)
 
+To write such a file, just call WRITE-HEX-TO-FILE function as following:
+
+    (intel-hex:write-hex-to-file #(0 0 0 ... #x21 #x46 #x01 ...) "/path/to/hex-file.hex")
+    => NIL
+
+or, if you want your file to start at some address,
+
+    (intel-hex:write-hex-to-file '(#x100 #(#x21 #x46 #x01 ...)) "/path/to/hex-file.hex")
+    => NIL
+
+
 ## Installation
 
 You can install via Quicklisp.
@@ -46,6 +57,39 @@ Reads Intel HEX format from a file named FILENAME and returns an array of bytes 
 
 Reads Intel HEX format from STRING and returns an array of bytes whose only dimension is SIZE.
 
+### [Function] write-hex
+
+    WRITE-HEX offset-and-data out &optional (chunk-size *default-chunk-size*) vector-size) => NIL
+
+Write Intel HEX format to STREAM.
+
+OFFSET-AND-DATA is a list of alternating initial addresses and vectors
+to be put at the address; as special case, a single vector (assumed to
+start at address 0) can be also used.
+
+May contain additional parameters; currently:
+- :chunk-size is supported to change size of individual lines (default
+  is `*default-chunk-size*`, that is initially 16
+- :vector-size can be used to store more than one octet data (e.g.,
+Microchip tools use 16bit for their midrange processors, so you would
+use 2 here).
+
+### [Function] write-hex-to-file
+
+    READ-HEX-FROM-FILE offset-and-data file &optional (chunk-size *default-chunk-size*) vector-size) => NIL
+
+Write Intel HEX format to a file named FILENAME.
+
+Parameters are analogous to WRITE-HEX; in addition, IF-EXISTS is
+passed to OPEN call.
+
+### [Function] write-hex-to-string
+
+    READ-HEX-FROM-STRING offset-and-data &optional (chunk-size *default-chunk-size*) vector-size) => NIL
+
+Write Intel HEX format to string.
+Parameters are analogous to WRITE-HEX.
+
 ## Record Types
 
 There are fix record types defined in Intel HEX format and their implementation status in the library is as following.
@@ -56,12 +100,13 @@ Hex code | Record type | Status
 '01' | End Of File Record | done.
 '02' | Extended Segment Address Record | not implemented.
 '03' | Start Segment Address Record | not implemented.
-'04' | Extended Linear Address Record | done.
+'04' | Extended Linear Address Record | reading only.
 '05' | Start Linear Address Record | not implemented.
 
 ## Author
 
 * Masayuki Takagi (kamonama@gmail.com)
+* Tomas Zellerin (zellerin@gmail.com) - writing hex files
 
 ## Copyright
 

--- a/intel-hex.asd
+++ b/intel-hex.asd
@@ -15,7 +15,9 @@
   :depends-on ()
   :components ((:module "src"
                 :components
-                ((:file "intel-hex"))))
+                ((:file "package")
+		 (:file "write" :depends-on ("package"))
+		 (:file "read" :depends-on ("package")))))
   :description "A library to handle Intel HEX format."
   :long-description
   #.(with-open-file (stream (merge-pathnames

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,0 +1,10 @@
+(in-package :cl-user)
+(defpackage intel-hex
+  (:use :cl)
+  (:export #:read-hex
+           #:read-hex-from-file
+           #:read-hex-from-string
+	   #:write-hex
+	   #:write-hex-to-file
+           #:write-hex-to-string
+	   #:*default-chunk-size*))

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -3,12 +3,6 @@
   Copyright (c) 2015 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-(defpackage intel-hex
-  (:use :cl)
-  (:export #:read-hex
-           #:read-hex-from-file
-           #:read-hex-from-string))
 (in-package :intel-hex)
 
 (defvar *check-sum* 0)

--- a/src/write.lisp
+++ b/src/write.lisp
@@ -107,7 +107,7 @@ OPS may contain additional parameters; currently:
   (force-output out))
 
 (defun write-hex-to-file (offset-and-data file &key (chunk-size *default-chunk-size*)
-						 vector-size (if-exists :supersede))
+						 vector-size (if-exists :error))
   "Print intel hex representation of one or multiple vectors to
 FILE.
 

--- a/src/write.lisp
+++ b/src/write.lisp
@@ -1,0 +1,126 @@
+;;;; Copyright (C) 2012, 2015, 2016 by Tomas Zellerin
+
+(in-package intel-hex)
+
+(defvar *default-chunk-size* #x10
+  "How many octets should go to one hex line.")
+
+(define-modify-macro update-checksum (octet)
+  (lambda (old-checksum octet)
+    (declare ((unsigned-byte 8) old-checksum octet))
+    (setf checksum (mod (- old-checksum octet) #x100)))
+  "Update value of checksum by a new octet.")
+
+(defun write-hex-line (out data start type length &optional
+			    (offset 0))
+  "Print one line of data in hex format to a stream.
+
+For type 00, LENGTH bytes starting at address START of vector DATA is written as
+data at address START+OFFSET.
+
+Type 01 is end of file record. The byte count is 00 and the data field
+is empty."
+  (assert (<= 0 (+ offset start) #xFFFF) ()
+	  "Only 16bit start addresses are suported, not ~x" start)
+  (assert (<= 0 type 5) () "Non-existent type code ~d" type)
+  (assert (<= 0 type 1) () "Unsupported type code ~d" type)
+  (when (= type 1)
+    (assert (zerop length) () "Non-zero length of e-o-f record"))
+  (format out "~&:~2,'0x" length)      ; prefix and byte count/size
+  (format out "~4,'0x" (+ offset start))  ; 16 bit address
+  ;;;; Record type, two hex digits, 00 to 05, defining the type of the data field.
+  (format out "~2,'0x" type) ;
+  ;; Data, a sequence of n bytes of the data themselves, represented by 2n hex digits.
+  (loop
+     with declared-start = (+ start offset)
+     with checksum = 0
+     for i from start below (+ start length)
+     for val = (aref data i)
+     initially
+       (update-checksum checksum length)
+       (update-checksum checksum type)
+       (update-checksum checksum (ldb (byte 8 0) declared-start))
+       (update-checksum checksum (ldb (byte 8 8) declared-start))
+     do
+       (assert (<= 0 val #xff))
+       (format out "~2,'0x" val)
+       (update-checksum checksum val)
+     finally
+       ;; check sum and end line
+       (format out "~2,'0x~%" checksum)))
+
+(defun write-hex-single-vector (data &optional (stream *terminal-io*) (offset 0)
+			 (chunk-size *default-chunk-size*))
+  "Print vector of octets DATA to the output stream STREAM as lines, each
+having up to CHUNK-SIZE octets. The address in the hex files differs
+from position in DATA by OFFSET.
+
+Do not print the end-of-file line."
+  (loop
+     for start from 0 upto (1- (length data)) by chunk-size
+     do
+       (write-hex-line stream data start
+			    0
+			    (min chunk-size (- (length data) start))
+			    offset)))
+
+(defun code-to-octets (byte-size-in-octets data)
+  "Convert 16bit or 32 bit vector DATA to twice or four times as long
+vector of octets."
+  (loop
+    with res = (make-array (* byte-size-in-octets (length data))
+			   :element-type '(unsigned-byte 8)
+			   :fill-pointer 0)
+     for orig across data
+     for i from 0 by byte-size-in-octets
+     do
+       (loop for octet from 0 to (1- byte-size-in-octets)
+	  do
+	    (vector-push  (ldb (byte 8 (* 8 octet)) orig) res))
+     finally
+       (return res)))
+
+(defun write-hex (offset-and-data &optional (out *standard-output*)
+					    (chunk-size *default-chunk-size*)
+					    vector-size)
+"OFFSET-AND-DATA is a list of alternating initial addresses and vectors
+to be put at the address; as special case, a single vector (assumed to
+start at address 0) can be also used.
+
+OPS may contain additional parameters; currently:
+- :chunk-size is supported to change size of individual lines,
+- :vector-size can be used to store more than one octet data (e.g., Microchip
+  tools use 16bit for their midrange processors, so use 2 here).
+  Start addresses are multiplied by the factor as well (is this correct behaviour?)."
+  (flet ((converted (data)
+	      (if vector-size
+		  (code-to-octets vector-size data)
+		  data)))
+	(if (atom offset-and-data)
+	    (write-hex-single-vector (converted offset-and-data) out 0 chunk-size)
+	    (loop
+	      for (offset data) on offset-and-data
+	      by #'cddr
+	      do (write-hex-single-vector (converted data)
+					  out  (* (or vector-size 1) offset) chunk-size))))
+  (write-hex-line out #() 0 1 0)
+  (force-output out))
+
+(defun write-hex-to-file (offset-and-data file &key (chunk-size *default-chunk-size*)
+						 vector-size (if-exists :supersede))
+  "Print intel hex representation of one or multiple vectors to
+FILE.
+
+Parameters are analogous to WRITE-HEX; in addition, IF-EXISTS is
+passed to OPEN call."
+  (with-open-file (out file :direction :output
+		       :if-exists if-exists)
+    (write-hex offset-and-data out chunk-size vector-size)))
+
+(defun write-hex-to-string (offset-and-data &key (chunk-size *default-chunk-size*)
+						 vector-size)
+  "Print intel hex representation of one or multiple vectors to a string.
+
+Parameters are analogous to WRITE-HEX."
+  (with-output-to-string (out)
+    (write-hex offset-and-data out chunk-size vector-size)))

--- a/t/intel-hex.lisp
+++ b/t/intel-hex.lisp
@@ -94,5 +94,31 @@
 (let ((bytes (read-hex-from-string 256 ":00000001FF")))
   (is (aref bytes #x00) #x00 "The first byte of the array is 0x00."))
 
+;;;
+;;; test WRITE-HEX-LINE
+;;;
+
+(diag "WRITE-HEX-LINE")
+
+(is
+ (remove #\NewLine
+	 (with-output-to-string (out)
+	   (intel-hex::write-hex-line out #(02 #x33 #x7a) 0 0 3 #x30)))
+   ":0300300002337A1E")
+
+;;;
+;;; test WRITE-HEX-TO-STRING
+;;;
+(diag "WRITE-HEX-TO-STRING (simple)")
+  
+(is (equalp (read-hex-from-string 6 (write-hex-to-string #1=#(10 11 23 45 32 94)))
+	    #1#) t)
+
+(diag "WRITE-HEX-TO-STRING (with offset)")
+  
+(is (equalp (subseq (read-hex-from-string #x106 (write-hex-to-string '(#x100 #1=#(10 11 23 45 32 94))))
+		    #x100)
+	    #1#) t)
+
 
 (finalize)


### PR DESCRIPTION
Names of the (exported) write functions made analogous to the read ones.

Different behaviours from read:
- both vector and list of alternating addresses and vectors allowed.
- only type 0 and 1 lines are generated
- allows storing from 16 or 32 (or whatever octet multiple) bit vectors as
  well.

Separated package.lisp.

Documentation is updated. Some tests added. Not all cases covered by
tests, though.
